### PR TITLE
Adding bottle as install dependency

### DIFF
--- a/mailtest.py
+++ b/mailtest.py
@@ -3,7 +3,11 @@ import asyncore, collections, email, json, smtpd, sys, threading, time
 from wsgiref.simple_server import make_server, WSGIRequestHandler, WSGIServer
 import bottle
 
-__version__ = '1.1.3'
+try:
+    VERSION = __import__('pkg_resources') \
+        .get_distribution('mailtest').version
+except Exception as e:
+    VERSION = 'unknown'
 
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@ import os
 
 from setuptools import setup
 
+VERSION = '1.1.3'
+
 def long_description():
   os.system('pandoc --from=markdown --to=rst --output=README.rst README.md')
   readme_fn = os.path.join(os.path.dirname(__file__), 'README.rst')
@@ -13,13 +15,16 @@ def long_description():
 
 setup(
   name='mailtest',
-  version=__import__('mailtest').__version__,
+  version=VERSION,
   description="A unit testing tool for code that sends email.",
   long_description=long_description(),
   author='Derek Anderson',
   author_email='public@kered.org',
   url='https://github.com/keredson/mailtest',
   packages=[],
+  install_requires=[
+    'bottle'
+    ],
   py_modules=['mailtest'],
   classifiers=[
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
Needed to move definition of `VERSION` into setup.py and
redefine `__version__` in the mailtest.py based on that, instead of doing
it the other way around.

resolves  #1